### PR TITLE
Clean up Dell Insyde docs to note that it works with Inspiron 5537, add example to webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Latest released version available [here][bios-pw] and latest testing version (*s
 * Asus &mdash; current BIOS date. For example: ``01-02-2013``
 * Compaq &mdash; 5 decimal digits (*e.g*. ``12345``)
 * Dell	&mdash; supports such series: ``595B``, ``D35B``, ``2A7B``, ``A95B``, ``1D3B``, ``6FF1``, ``1F66``, ``1F5A`` and ``BF97``, ``E7A8``. *e.g*: ``1234567-2A7B`` or ``1234567890A-D35B`` for HDD.
-* Dell Insyde BIOS (Latitude 3540) &mdash; *e.g.* ``5F3988D5E0ACE4BF-7QH8602`` (``7QH8602`` &mdash; service tag).
+* Dell Insyde (Latitude 3540, Inspiron 5537) &mdash; 16 hexadecimal digits + service tag. *e.g.* ``5F3988D5E0ACE4BF-7QH8602`` (``7QH8602`` being the service tag).
 * Fujitsu-Siemens &mdash; 5 decimal digits, 8 hexadecimal digits, 5x4 hexadecimal digits, 5x4 decimal digits
 * Hewlett-Packard &mdash; 5 decimal digits, 10 characters
 * Insyde H20 (Acer, HP) &mdash; 8 decimal digits, 10 decimal digits or HP `i ` (lowercase and uppercase) prefixed 8 digits.

--- a/html/index.html
+++ b/html/index.html
@@ -50,6 +50,7 @@
 <tr style="background: #ddd;"><th>Vendor</th><th>Type</th><th>Hash Code/Serial example</th></tr>
 <tr><td class="s3" style="font-weight: bold;">Compaq</td><td class="s4">5 decimal digits</td><td class="s5" style="font-family: monospace;">12345</td></tr>
 <tr><td class="s3" style="font-weight: bold;">Dell</td><td class="s4">serial number</td><td class="s5" style="font-family: monospace;">1234567-595B<br>1234567-D35B<br>1234567-2A7B<br>1234567-1D3B<br>1234567-1F66<br>1234567-6FF1<br>1234567-1F5A<br>1234567-BF97</td></tr>
+<tr><td class="s3" style="font-weight: bold;">Dell Insyde</td><td class="s4">16 hexadecimal digits + service tag</td><td class="s5" style="font-family: monospace;">5F3988D5E0ACE4BF-7QH8602</td></tr>
 <tr><td class="s7" style="font-weight: bold;">Fujitsu-Siemens</td><td class="s8">5 decimal digits</td><td class="s9" style="font-family: monospace;">12345</td></tr>
 <tr><td class="s7" style="font-weight: bold;">Fujitsu-Siemens</td><td class="s8">8 hexadecimal digits</td><td class="s9" style="font-family: monospace;">DEADBEEF</td></tr>
 <tr><td class="s7" style="font-weight: bold;">Fujitsu-Siemens</td><td class="s8">5x4 hexadecimal digits</td><td class="s9" style="font-family: monospace;">AAAA-BBBB-CCCC-DEAD-BEEF</td></tr>

--- a/src/keygen/dell/index.ts
+++ b/src/keygen/dell/index.ts
@@ -284,7 +284,7 @@ const latitude3540RE = /^([0-9A-F]{16})([0-9A-Z]{7})$/i;
 // TODO: implement solver with 2 inputs
 export let dellLatitude3540Solver = makeSolver({
     name: "dellLatitude3540",
-    description: "Dell Latitude 3540",
+    description: "Dell Insyde",
     examples: ["5F3988D5E0ACE4BF-7QH8602"],
     inputValidator: (pwd) => latitude3540RE.test(pwd),
     fun: (input: string) => {


### PR DESCRIPTION
Just tried the Dell Insyde hash (originally intended for just Latitude 3540 I think?) on my Dell Inspiron 5537 and it works, so here's some documentation noting that. I also noticed that the entire Insyde algorithm is missing from the website page so I added that too.